### PR TITLE
Add pagination to admin lists

### DIFF
--- a/src/java/controller/admin/MovieAdminController.java
+++ b/src/java/controller/admin/MovieAdminController.java
@@ -31,10 +31,15 @@ public class MovieAdminController extends HttpServlet {
             return;
         }
         if (!isAdmin(req)) { resp.setStatus(401); return; }
-        List<Movie> movies = MovieDAO.findAll();
+        int page = 1;
+        int size = 10;
+        try { page = Integer.parseInt(req.getParameter("page")); } catch (Exception e) {}
+        try { size = Integer.parseInt(req.getParameter("size")); } catch (Exception e) {}
+        List<Movie> movies = MovieDAO.findPage((page-1)*size, size);
+        int total = MovieDAO.count();
         resp.setContentType("application/json;charset=UTF-8");
         PrintWriter out = resp.getWriter();
-        out.write(SimpleJson.moviesToJson(movies));
+        out.write("{\"total\":"+total+",\"page\":"+page+",\"movies\":"+SimpleJson.moviesToJson(movies)+"}");
     }
 
     @Override

--- a/src/java/controller/admin/PackageAdminController.java
+++ b/src/java/controller/admin/PackageAdminController.java
@@ -31,10 +31,15 @@ public class PackageAdminController extends HttpServlet {
             return;
         }
         if (!isAdmin(req)) { resp.setStatus(401); return; }
-        List<Package> packages = PackageDAO.findAll();
+        int page = 1;
+        int size = 10;
+        try { page = Integer.parseInt(req.getParameter("page")); } catch (Exception e) {}
+        try { size = Integer.parseInt(req.getParameter("size")); } catch (Exception e) {}
+        List<Package> packages = PackageDAO.findPage((page-1)*size, size);
+        int total = PackageDAO.count();
         resp.setContentType("application/json;charset=UTF-8");
         PrintWriter out = resp.getWriter();
-        out.write(util.SimpleJson.packagesToJson(packages));
+        out.write("{\"total\":"+total+",\"page\":"+page+",\"packages\":"+util.SimpleJson.packagesToJson(packages)+"}");
     }
 
     @Override

--- a/src/java/controller/admin/PromotionAdminController.java
+++ b/src/java/controller/admin/PromotionAdminController.java
@@ -47,7 +47,12 @@ public class PromotionAdminController extends HttpServlet {
             return;
         }
         if (!isAdmin(req)) { resp.setStatus(401); return; }
-        List<Promotion> list = PromotionDAO.findAll();
+        int page = 1;
+        int size = 10;
+        try { page = Integer.parseInt(req.getParameter("page")); } catch (Exception e) {}
+        try { size = Integer.parseInt(req.getParameter("size")); } catch (Exception e) {}
+        List<Promotion> list = PromotionDAO.findPage((page-1)*size, size);
+        int total = PromotionDAO.count();
         java.util.List<java.util.Map<String,Object>> arr = new java.util.ArrayList<>();
         for (Promotion p : list) {
             arr.add(java.util.Map.of(
@@ -62,7 +67,7 @@ public class PromotionAdminController extends HttpServlet {
         }
         resp.setContentType("application/json;charset=UTF-8");
         PrintWriter out = resp.getWriter();
-        out.write(SimpleJson.listToJson(arr));
+        out.write("{\"total\":"+total+",\"page\":"+page+",\"promotions\":"+SimpleJson.listToJson(arr)+"}");
     }
 
     @Override

--- a/src/java/controller/admin/UserAdminController.java
+++ b/src/java/controller/admin/UserAdminController.java
@@ -30,10 +30,15 @@ public class UserAdminController extends HttpServlet {
             return;
         }
         if (!isAdmin(req)) { resp.setStatus(401); return; }
-        List<User> users = UserDAO.findAllUsers();
+        int page = 1;
+        int size = 10;
+        try { page = Integer.parseInt(req.getParameter("page")); } catch (Exception e) {}
+        try { size = Integer.parseInt(req.getParameter("size")); } catch (Exception e) {}
+        List<User> users = UserDAO.findPage((page-1)*size, size);
+        int total = UserDAO.count();
         resp.setContentType("application/json;charset=UTF-8");
         PrintWriter out = resp.getWriter();
-        out.write(SimpleJson.usersToJson(users));
+        out.write("{\"total\":"+total+",\"page\":"+page+",\"users\":"+SimpleJson.usersToJson(users)+"}");
     }
 
     @Override

--- a/src/java/dao/movie/MovieDAO.java
+++ b/src/java/dao/movie/MovieDAO.java
@@ -123,6 +123,43 @@ public class MovieDAO {
         return list;
     }
 
+    public static List<Movie> findPage(int offset, int limit) {
+        String sql = "SELECT * FROM movies WHERE is_deleted=0 LIMIT ? OFFSET ?";
+        Connection conn = DBConnection.getConnection();
+        List<Movie> list = new ArrayList<>();
+        if (conn == null) return list;
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, limit);
+            ps.setInt(2, offset);
+            ResultSet rs = ps.executeQuery();
+            while (rs.next()) {
+                list.add(map(rs));
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        } finally {
+            DBConnection.closeConnection(conn);
+        }
+        return list;
+    }
+
+    public static int count() {
+        String sql = "SELECT COUNT(*) FROM movies WHERE is_deleted=0";
+        Connection conn = DBConnection.getConnection();
+        if (conn == null) return 0;
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ResultSet rs = ps.executeQuery();
+            if (rs.next()) {
+                return rs.getInt(1);
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        } finally {
+            DBConnection.closeConnection(conn);
+        }
+        return 0;
+    }
+
 
        public static Movie getMovieById(int id) {
         String sql = "SELECT * FROM movies WHERE id=?";

--- a/src/java/dao/pkg/PackageDAO.java
+++ b/src/java/dao/pkg/PackageDAO.java
@@ -96,6 +96,43 @@ public class PackageDAO {
         return list;
     }
 
+    public static List<Package> findPage(int offset, int limit) {
+        String sql = "SELECT * FROM package WHERE is_deleted=0 LIMIT ? OFFSET ?";
+        Connection conn = DBConnection.getConnection();
+        List<Package> list = new ArrayList<>();
+        if (conn == null) return list;
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, limit);
+            ps.setInt(2, offset);
+            ResultSet rs = ps.executeQuery();
+            while (rs.next()) {
+                list.add(map(rs));
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        } finally {
+            DBConnection.closeConnection(conn);
+        }
+        return list;
+    }
+
+    public static int count() {
+        String sql = "SELECT COUNT(*) FROM package WHERE is_deleted=0";
+        Connection conn = DBConnection.getConnection();
+        if (conn == null) return 0;
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ResultSet rs = ps.executeQuery();
+            if (rs.next()) {
+                return rs.getInt(1);
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        } finally {
+            DBConnection.closeConnection(conn);
+        }
+        return 0;
+    }
+
     private static Package map(ResultSet rs) throws SQLException {
         Package p = new Package();
         p.setId(rs.getInt("id"));

--- a/src/java/dao/promo/PromotionDAO.java
+++ b/src/java/dao/promo/PromotionDAO.java
@@ -97,6 +97,33 @@ public class PromotionDAO {
         return list;
     }
 
+    public static List<Promotion> findPage(int offset, int limit) {
+        String sql = "SELECT * FROM promotion LIMIT ? OFFSET ?";
+        Connection conn = DBConnection.getConnection();
+        List<Promotion> list = new ArrayList<>();
+        if (conn == null) return list;
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, limit);
+            ps.setInt(2, offset);
+            ResultSet rs = ps.executeQuery();
+            while (rs.next()) list.add(map(rs));
+        } catch (SQLException e) { e.printStackTrace(); }
+        finally { DBConnection.closeConnection(conn); }
+        return list;
+    }
+
+    public static int count() {
+        String sql = "SELECT COUNT(*) FROM promotion";
+        Connection conn = DBConnection.getConnection();
+        if (conn == null) return 0;
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ResultSet rs = ps.executeQuery();
+            if (rs.next()) return rs.getInt(1);
+        } catch (SQLException e) { e.printStackTrace(); }
+        finally { DBConnection.closeConnection(conn); }
+        return 0;
+    }
+
     private static Promotion map(ResultSet rs) throws SQLException {
         Promotion p = new Promotion();
         p.setId(rs.getInt("id"));

--- a/src/java/dao/user/UserDAO.java
+++ b/src/java/dao/user/UserDAO.java
@@ -241,6 +241,47 @@ public class UserDAO {
         return list;
     }
 
+    public static List<User> findPage(int offset, int limit) {
+        String sql = "SELECT * FROM users WHERE is_deleted = 0 LIMIT ? OFFSET ?";
+        Connection conn = DBConnection.getConnection();
+        List<User> list = new ArrayList<>();
+        if (conn == null) return list;
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, limit);
+            ps.setInt(2, offset);
+            ResultSet rs = ps.executeQuery();
+            while (rs.next()) {
+                User u = new User();
+                u.setId(rs.getInt("id"));
+                u.setEmail(rs.getString("email"));
+                u.setRole(rs.getString("role"));
+                list.add(u);
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        } finally {
+            DBConnection.closeConnection(conn);
+        }
+        return list;
+    }
+
+    public static int count() {
+        String sql = "SELECT COUNT(*) FROM users WHERE is_deleted = 0";
+        Connection conn = DBConnection.getConnection();
+        if (conn == null) return 0;
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ResultSet rs = ps.executeQuery();
+            if (rs.next()) {
+                return rs.getInt(1);
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        } finally {
+            DBConnection.closeConnection(conn);
+        }
+        return 0;
+    }
+
     public static boolean lockUser(int id, boolean lock) {
         String sql = "UPDATE users SET locked = ? WHERE id = ?";
         Connection conn = DBConnection.getConnection();

--- a/web/jsp/admin/movies.jsp
+++ b/web/jsp/admin/movies.jsp
@@ -29,15 +29,21 @@
         </thead>
         <tbody></tbody>
       </table>
+      <div id="pagination" class="pagination"></div>
     </div>
   </section>
 </main>
 <script>
 const base = '<%=request.getContextPath()%>';
 const token = localStorage.getItem('adminToken');
-function load(){
-  fetch(base + '/api/admin/movies',{headers:{Authorization:'Bearer '+token}})
-    .then(r=>r.json()).then(list=>{
+let currentPage = 1;
+const pageSize = 10;
+function load(page=currentPage){
+  currentPage = page;
+  fetch(base + '/api/admin/movies?page='+page+'&size='+pageSize,{headers:{Authorization:'Bearer '+token}})
+    .then(r=>r.json()).then(res=>{
+      const list=res.movies;
+      const total=res.total;
       const tb=document.querySelector('#movieTable tbody');
       tb.innerHTML='';
       list.forEach(m=>{
@@ -47,19 +53,33 @@ function load(){
           `<td><button data-id="${m.id}" data-delete="true">Delete</button></td>`;
         tb.appendChild(tr);
       });
+      renderPagination(total);
     });
+}
+
+function renderPagination(total){
+  const totalPages = Math.ceil(total/pageSize);
+  const pag=document.getElementById('pagination');
+  pag.innerHTML='';
+  for(let i=1;i<=totalPages;i++){
+    const btn=document.createElement('button');
+    btn.textContent=i;
+    if(i===currentPage) btn.disabled=true;
+    btn.addEventListener('click',()=>load(i));
+    pag.appendChild(btn);
+  }
 }
 document.getElementById('movieForm').addEventListener('submit',async e=>{
   e.preventDefault();
   const data=new URLSearchParams(new FormData(e.target));
   await fetch(base+'/api/admin/movies',{method:'POST',headers:{Authorization:'Bearer '+token},body:data});
   e.target.reset();
-  load();
+  load(currentPage);
 });
 document.addEventListener('click',async e=>{
   if(e.target.dataset.delete){
     await fetch(base+'/api/admin/movie/'+e.target.dataset.id,{method:'DELETE',headers:{Authorization:'Bearer '+token}});
-    load();
+    load(currentPage);
   }
 });
 load();

--- a/web/jsp/admin/packages.jsp
+++ b/web/jsp/admin/packages.jsp
@@ -26,15 +26,21 @@
         </thead>
         <tbody></tbody>
       </table>
+      <div id="pagination" class="pagination"></div>
     </div>
   </section>
 </main>
 <script>
 const base = '<%=request.getContextPath()%>';
 const token = localStorage.getItem('adminToken');
-function load(){
-  fetch(base + '/api/admin/packages',{headers:{Authorization:'Bearer '+token}})
-    .then(r=>r.json()).then(list=>{
+let currentPage = 1;
+const pageSize = 10;
+function load(page=currentPage){
+  currentPage = page;
+  fetch(base + '/api/admin/packages?page='+page+'&size='+pageSize,{headers:{Authorization:'Bearer '+token}})
+    .then(r=>r.json()).then(res=>{
+      const list=res.packages;
+      const total=res.total;
       const tb=document.querySelector('#pkgTable tbody');
       tb.innerHTML='';
       list.forEach(p=>{
@@ -44,19 +50,33 @@ function load(){
           `<td><button data-id="${p.id}" data-delete="true">Delete</button></td>`;
         tb.appendChild(tr);
       });
+      renderPagination(total);
     });
+}
+
+function renderPagination(total){
+  const totalPages = Math.ceil(total/pageSize);
+  const pag=document.getElementById('pagination');
+  pag.innerHTML='';
+  for(let i=1;i<=totalPages;i++){
+    const btn=document.createElement('button');
+    btn.textContent=i;
+    if(i===currentPage) btn.disabled=true;
+    btn.addEventListener('click',()=>load(i));
+    pag.appendChild(btn);
+  }
 }
 document.getElementById('pkgForm').addEventListener('submit',async e=>{
   e.preventDefault();
   const data=new URLSearchParams(new FormData(e.target));
   await fetch(base+'/api/admin/packages',{method:'POST',headers:{Authorization:'Bearer '+token},body:data});
   e.target.reset();
-  load();
+  load(currentPage);
 });
 document.addEventListener('click',async e=>{
   if(e.target.dataset.delete){
     await fetch(base+'/api/admin/package/'+e.target.dataset.id,{method:'DELETE',headers:{Authorization:'Bearer '+token}});
-    load();
+    load(currentPage);
   }
 });
 load();


### PR DESCRIPTION
## Summary
- support database pagination for movies, packages, promotions and users
- expose page and total fields from admin APIs
- add simple pagination controls to admin JSP list pages

## Testing
- `ant compile` *(fails: libs.CopyLibs.classpath property is not set up)*

------
https://chatgpt.com/codex/tasks/task_b_688f911df4ac8322be52f7f91aa1362d